### PR TITLE
wikiに配置したインライン画像がはみ出すのを防止。

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -347,6 +347,10 @@ div.wiki li {
   margin-bottom: 4px;
 }
 
+div.wiki img {
+  max-width: 100%;
+}
+
 /***** My page layout *****/
 .mypage-box {
   color:#222;


### PR DESCRIPTION
Redmineのwikiで画像がはみ出す問題について、かのURLでこのプラグインが紹介されていますが、現在のバージョンだとはみ出してしまうようなので、その点のdiffを提案させていただきます。

紹介されていたのは以下のURLです。
http://redmine.jp/faq/general/scale-large-image-to-fit/

手元のRedmineは少し古いのですが 2.5.2.stable.13335 で確認しています。
