### PR TITLE
Redmine6に合わせてfont-sizeの設定を最新化

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -222,7 +222,7 @@ input[type="text"] {
 }
 
 textarea.wiki-edit {
-  font-size: 14px;
+  font-size: 0.875rem;
   font-family: "Osaka-Mono", "MS Gothic", sans-serif;
   letter-spacing: normal;
   line-height: 130%;
@@ -298,7 +298,7 @@ div.wiki li {
 }
 
 #login-form input#username, #login-form input#password {
-    font-size: 15px;
+    font-size: 0.9375rem;
     padding: 3px;
 }
 

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -17,7 +17,6 @@
 
 body {
   font-family: Meiryo, "Hiragino Kaku Gothic Pro", "MS PGothic", Verdana, sans-serif;
-  font-size: 13px;
   color: #222;
 }
 
@@ -26,7 +25,6 @@ h1, h2, h3, h4 {
 }
 
 #header h1 {
-  font-size: 22px;
   text-shadow: -1px -1px 1px rgba(0, 0, 0, 0.3);
 }
 
@@ -36,10 +34,6 @@ h1, h2, h3, h4 {
 
 #sidebar h3 {
   color: #484848
-}
-
-#main-menu li a {
-  font-size: 12px;
 }
 
 #main-menu li a.selected, #main-menu li a.selected:hover {
@@ -60,20 +54,8 @@ a#toggle-completed-versions {
 
 /***** Tables *****/
 
-table.list {
-  font-size: 12px;
-}
-
 table.list th {
   padding: 4px 2px
-}
-
-table.attributes {
-  font-size: 12px;
-}
-
-table.attributes td {
-  padding: 1px;
 }
 
 tr.changeset td.author {
@@ -94,11 +76,6 @@ tr.version.closed, tr.version.closed a {
 
 table.list.issues tr.closed td {
   opacity: 0.7;
-}
-
-tr.assigned-to-me td.assigned_to, tr.created-by-me td.author {
-  font-weight: bold;
-  font-size: 11px;
 }
 
 td.parent {
@@ -230,10 +207,6 @@ tr.priority-lowest a {
   color: #222;
 }
 
-.contextual {
-  font-size: 12px
-}
-
 .issue .contextual {
   margin: 0;
   padding: 2px 3px;
@@ -242,18 +215,10 @@ tr.priority-lowest a {
   border: 1px solid #e6e6cf;
 }
 
-/* submitボタンを押しやすく */
-input[type="submit"], input[type="reset"] {
-  -webkit-appearance: button;
-  cursor: pointer;
-  font-size: 12px;
-}
-
 /* テキストボックスで等幅フォントを使用 */
 
 input[type="text"] {
   font-family: "Osaka-Mono", "MS Gothic", sans-serif;
-  font-size: 100%;
 }
 
 textarea.wiki-edit {
@@ -273,10 +238,6 @@ div.issue div.subject p {
 
 div.issue .next-prev-links {
   color:#666;
-}
-
-.buttons {
-  font-size: 12px
 }
 
 div#activity dt .time {
@@ -300,10 +261,6 @@ form .attributes p {
   padding-bottom: 2px;
 }
 
-form#issue-form small {
-  font-size: 11px;
-}
-
 div.wiki-page .contextual a {
   opacity: 0.7
 }
@@ -313,7 +270,6 @@ ul.projects div.root a.project {
 }
 
 p.other-formats {
-  font-size: 12px;
   color: #484848;
 }
 
@@ -368,20 +324,6 @@ table.cal div.assigned-to-me a {
   border-top: 1px dashed #ccc;
 }
 
-/* サイドバーの幅を狭く */
-#sidebar {
-  width: 20%;
-  font-size: 12px;
-}
-
-#content {
-  width: 77%;
-}
-
-* html #content{
-  width: 77%;
-}
-
 /* 作成日・更新日に実際の日時を表示 */
 a[href*="activity"][data-absolute-date*=":"] {
   margin: 0 3px;
@@ -394,10 +336,6 @@ a[href*="activity"][data-absolute-date*=":"]:before {
   content: ' [' attr(data-absolute-date) '] ';
 }
 
-.author {
-  font-size: 12px;
-}
-
 div.projects.box > ul > li > a {
   font-weight: bold;
 }
@@ -408,7 +346,6 @@ div.journal {
 }
 
 div.journal ul.details {
-  font-size: 12px;
   color: #444;
   background: #f6f6f6;
   border-radius: 3px;
@@ -427,9 +364,7 @@ div.journal ul.details i:after {
   font-style: normal;
 }
 
-div.journal h4:first-child {
-  font-size: 12px;
-  font-weight: normal;
+div.journal h4.note-header {
   color: #444;
 }
 


### PR DESCRIPTION
このプルリクエストではフォントサイズをRedmine6のDefaultテーマを踏まえて変更しています。
  
#### 変更内容:

- フォントサイズが Default テーマより小さいか同じの場合 → フォントサイズの上書きを削除  
- フォントサイズが Default テーマより大きい場合 → 上書きは維持しつつ、フォントサイズの単位を `px` から `rem` に変更  

また、フォントサイズの変更を行う過程で Redmine 本体に同等のスタイルが適用されているなど、上書きが不要と判断できるスタイルをいくつか削除しました。  
