### PR TITLE
等幅フォントをRedmine本体が利用している等幅フォントのfont-familyと同じに変更する

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -218,12 +218,12 @@ tr.priority-lowest a {
 /* テキストボックスで等幅フォントを使用 */
 
 input[type="text"] {
-  font-family: "Osaka-Mono", "MS Gothic", sans-serif;
+  font-family: Consolas, Menlo, "Liberation Mono", Courier, monospace;
 }
 
 textarea.wiki-edit {
   font-size: 0.875rem;
-  font-family: "Osaka-Mono", "MS Gothic", sans-serif;
+  font-family: Consolas, Menlo, "Liberation Mono", Courier, monospace; /* デフォルトを書き換えるだけ。Redmineの個人設定でテキストエリアのフォントをデフォルトから変更している場合はそちらのフォントが優先される */
   letter-spacing: normal;
   line-height: 130%;
 }


### PR DESCRIPTION
このプルリクエストでは、テーマによって上書きしているフォント（等幅フォント）の内容を現在の `"Osaka-Mono", "MS Gothic", sans-serif` から Redmineの個人設定で「テキストエリアのフォント」設定を等幅にしているときのフォントと同じ `Consolas, Menlo, "Liberation Mono", Courier, monospace`  になるように変更します。
https://github.com/redmine/redmine/blob/6.0.3/app/assets/stylesheets/application.css#L644

このテーマによる等幅フォントへの上書きは、あくまでも Redmineの個人設定の「テキストエリアのフォント」設定がデフォルトの場合にのみ適用されるもので、等幅かプロポーショナルを選択されている場合はそちらの設定が優先されます。
https://github.com/redmine/redmine/blob/6.0.3/app/assets/stylesheets/application.css#L644-L645

## 変更内容:

* input[type="text"]のfont-familyをConsolas, Menlo, "Liberation Mono", Courier, monospaceに変更
  *  input[type="text"]にはRedmineの個人設定の「テキストエリアのフォント」設定は適用されない
* textarea.wiki-editのfont-familyをConsolas, Menlo, "Liberation Mono", Courier, monospaceに変更

## テストしたこと:

テキストエリアのfont-familyが以下のように設定によって切り替わること (テーマで定義したfont-familyがRedmineの個人設定の「テキストエリアのフォント」設定より優先されないこと)

|   Redmineの個人設定の「テキストエリアのフォント」設定 |  font-family  |
| ---- | ---- |
|  デフォルト  |   Consolas, Menlo, "Liberation Mono", Courier, monospace (このテーマによって定義されたスタイル) |
|  等幅  |  Consolas, Menlo, "Liberation Mono", Courier, monospace (Redmine本体によって定義されたスタイル)  |
|プロポーショナル| "Noto Sans", sans-serif; (Redmine本体によって定義されたスタイル) |