### PR TITLE
Redmine 6.0 向けのインストール手順を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,15 @@ Redmineのインストールディレクトリで以下のコマンドを実行�
 git clone https://github.com/farend/redmine_theme_farend_basic.git themes/farend_basic
 ```
 
-#### Redmine5.1以前の場合
+#### Redmine 6.0 の場合
+
+Redmineのインストールディレクトリで以下のコマンドを実行してください。
+
+```
+git clone -b redmine6.0 https://github.com/farend/redmine_theme_farend_basic.git themes/farend_basic
+```
+
+#### Redmine 5.1 以前の場合
 
 Redmineのインストールディレクトリで以下のコマンドを実行してください。
 


### PR DESCRIPTION
master ブランチで、Redmine 6.1 の履歴画面のスタイル変更
https://www.redmine.org/issues/40744 に対応したため、Redmine 6.0 は redmine6.0 タグを使うように説明を追加する。