### PR TITLE
Adjust for Redmine issue 43937

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -28,12 +28,6 @@ h1, h2, h3, h4 {
   color: var(--oc-gray-9, #212529); /* Initial value is fallbak for Redmine < 7.0 */
 }
 
-#main-menu li a.selected, #main-menu li a.selected:hover {
-  color: var(--oc-gray-9, #212529);
-  box-shadow: 3px -2px 2px rgba(0, 0, 0, 0.1);
-}
-
-
 /***** Links *****/
 
 a.issue.closed, a.issue.closed:link, a.issue.closed:visited {


### PR DESCRIPTION
## Summary

Fix layout issues to align with the changes in Redmine core header (https://www.redmine.org/issues/43937).

## What Changed

- Removed specific styles for `#main-menu li a.selected` (color and box-shadow) to stay consistent with the core header updates.
  - These legacy styles were interfering with the new underline indicator for selected tabs introduced in Redmine core. Removing them ensures the underline is displayed correctly.

## Screenshots

Default theme
<img width="959" height="110" alt="screenshot 2026-04-21 11 24 49" src="https://github.com/user-attachments/assets/4786e3ed-9d0a-473f-9091-d8d13b015211" />

farend_basic theme (after change)
<img width="959" height="114" alt="screenshot 2026-04-21 11 29 22" src="https://github.com/user-attachments/assets/3d0826f7-09a0-43f2-a8cd-14e7df25463a" />


farend_basic theme (before change)
<img width="959" height="114" alt="screenshot 2026-04-21 11 27 58" src="https://github.com/user-attachments/assets/3967cd9a-3391-4b75-8bbd-f826a61002c1" />


# Note

- Any difference in text width compared to the default theme is caused by the difference in the font family used in farend_basic.