### PR TITLE
Redmine本体に合わせるために.issue .contextualスタイルを削除する

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -189,14 +189,6 @@ tr.priority-lowest a {
   color: var(--oc-gray-9, #212529);
 }
 
-.issue .contextual {
-  margin: 0;
-  padding: 2px 3px;
-  border-radius: 3px;
-  background: rgba(var(--oc-white-rgb, 255, 255, 255), 0.8);
-  border: 1px solid var(--oc-gray-4, #ced4da);
-}
-
 /* proportional でない場合にフォントを変更 */
 body:not(.textarea-proportional) input[type="text"], body:not(.textarea-proportional) textarea.wiki-edit {
   font-family: "Osaka-Mono", "MS Gothic", monospace;


### PR DESCRIPTION
## 概要

Redmine本体のスタイル変更の影響でチケット表示画面のページネーションにスタイルが二重に適用されていることが分かりました。
検討した結果、.issue .contextual要素に対して背景色やボーダーを定義するのをやめ、Redmineのデフォルトテーマと同じ見た目にします。
.issue .contextual要素はページネーションだけでなくチケット表示画面内の引用やAddにも当てはまります。

## Screenshots

|  before  |  after  |
| ---- | ---- |
|  <img width="292" height="479" alt="screenshot 2026-04-27 13 08 35" src="https://github.com/user-attachments/assets/166014fc-3fba-47b4-a035-2dcf46981153" />  |  <img width="292" height="479" alt="screenshot 2026-04-27 13 08 45" src="https://github.com/user-attachments/assets/76fbff58-930a-4579-834f-87384fed78d7" />  |